### PR TITLE
update jedis dependency from 2.1.0 to 2.2.0.  Alleviates issue in using ...

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -16,7 +16,7 @@ grails.project.dependency.resolution = {
 		compile 'ru.zinin:tomcat-redis-session:0.5', {
 			excludes 'commons-pool', 'jedis', 'tomcat-catalina', 'tomcat-jasper', 'tomcat-servlet-api'
 		}
-		compile 'redis.clients:jedis:2.1.0', {
+		compile 'redis.clients:jedis:2.2.0', {
 			excludes 'commons-pool', 'junit'
 		}
 	}


### PR DESCRIPTION
...this plugin and the latest redis plugin, as documented here:

https://github.com/xetorthio/jedis/issues/303
