### PR TITLE
Update BuildConfig.groovy

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -13,7 +13,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		compile 'ru.zinin:tomcat-redis-session:0.5', {
+		compile 'ru.zinin:tomcat-redis-session:0.6', {
 			excludes 'commons-pool', 'jedis', 'tomcat-catalina', 'tomcat-jasper', 'tomcat-servlet-api'
 		}
 		compile 'redis.clients:jedis:2.2.0', {


### PR DESCRIPTION
I still have several issue using this plugin in combination with redis plugin. there are runtime problem, mostly due to differnt jedis library I suppose.

I hope that bumping tomcat-redis-session library from 0.5 to 0.6 will fix that.

this si my stacktrace: java.lang.RuntimeException: java.lang.NoSuchMethodError: redis.clients.jedis.Transaction.sadd(Ljava/lang/String;Ljava/lang/String;)Lredis/clients/jedis/Response;
